### PR TITLE
Fix "Internal Server Error" (HTTP 400) from Kroki with reason "TooLongFormFieldException".

### DIFF
--- a/includes/ParserKrokiTag.php
+++ b/includes/ParserKrokiTag.php
@@ -201,6 +201,7 @@ class ParserKrokiTag {
 
 		// Create HttpRequest
 		$request = MediaWikiServices::getInstance()->getHttpRequestFactory()->create( $url, $requestParams, __METHOD__ );
+		$request->setHeader( 'Content-Type', 'application/json; charset=utf-8' );
 
 		// Send the request
 		$status = $request->execute();
@@ -252,6 +253,7 @@ class ParserKrokiTag {
 
 		// Create HttpRequest
 		$request = MediaWikiServices::getInstance()->getHttpRequestFactory()->create( $url, $requestParams, __METHOD__ );
+		$request->setHeader( 'Content-Type', 'application/json; charset=utf-8' );
 
 		// Send the request
 		$status = $request->execute();


### PR DESCRIPTION
Fix "Internal Server Error" (HTTP 400) from Kroki with reason "TooLongFormFieldException" ("io.netty.handler.codec.http.multipart.HttpPostRequestDecoder$TooLongFormFieldException").
Using the default content-type "application/x-www-form-urlencoded" may cause Kroki to break due to large diagram (https://github.com/yuzutech/kroki/issues/1827).